### PR TITLE
Updated pom so that proper dockerfile is picked up

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
               <buildArgs>
                 <JAR_FILE>${project.artifactId}-${project.version}.jar</JAR_FILE>
               </buildArgs>
+              <dockerfile>${project.basedir}/Dockerfile</dockerfile>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
When working on docker command, it  gave docker file null, so updating that.
![image](https://user-images.githubusercontent.com/74582859/114879334-b6528180-9e1e-11eb-88fe-79568a330706.png)

I feel currently in case of null its falling back to basedir/dockerfile.

This change might not be necessary, but still.